### PR TITLE
NETMF moved to GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ There are many projects under the stewardship of the .NET Foundation. The [full 
 - [.NET Core CLR](https://github.com/dotnet/coreclr)
 - [.NET Core Framework](https://github.com/dotnet/corefx)
 - [.NET Compiler Platform ("Roslyn")](https://github.com/dotnet/roslyn)
+- [.NET Micro Framework](https://github.com/NETMF/netmf-interpreter)
 - [ASP.NET 5](https://github.com/aspnet/home) 
 - [ASP.NET SignalR](https://github.com/SignalR/SignalR)
 - [Azure SDK for .NET](https://github.com/Azure/azure-sdk-for-net)

--- a/projects/dotnet-micro-framework.md
+++ b/projects/dotnet-micro-framework.md
@@ -1,15 +1,15 @@
 # .NET Micro Framework
 
-The [Microsoft® .NET Micro Framework](https://netmf.codeplex.com/) combines the reliability and efficiency of managed code with the premier development tools of Microsoft Visual Studio® to deliver exceptional productivity for developing embedded applications on small devices. 
+The [Microsoft® .NET Micro Framework](https://netmf.github/io/) is an open source platform that enables you to write managed code C# applications using Visual Studio for resource constrained embedded devices.
 
 The Microsoft .NET Micro Framework SDK supports development of code, including device I/O, in the C# language using a subset of the .NET libraries, and is fully integrated with the Microsoft Visual Studio® development environment. The .NET Micro Framework class library supports all major namespaces and types from the desktop framework, managed drivers support, Remote Firmware Updates and Cryptographic functions for Secure Devices.
 
 ## Project Details
-* [Project Info Site](https://netmf.codeplex.com/) 
-* [Project Code Site](https://netmf.codeplex.com/SourceControl/latest) 
-* Project License Type: [Apache License 2.0](https://netmf.codeplex.com/license)
-* Project Main Contact: [Steve Maillet](https://www.codeplex.com/site/users/view/smaillet_ms) 
+* [Project Info Site](https://netmf.github.io/) 
+* [Project Code Site](https://github.com/NETMF/netmf-interpreter) 
+* Project License Type: [Apache License 2.0](https://github.com/NETMF/netmf-interpreter/blob/dev/License.txt)
+* Project Main Contact: [Steve Maillet](https://github.com/smaillet-ms)
 
 ## Quicklinks
 
-* [Documentation](https://netmf.codeplex.com/documentation)
+* [Wiki](https://github.com/NETMF/netmf-interpreter/wiki)


### PR DESCRIPTION
The .NET Micro Framework has moved new development to GitHub. Update project pages.