### PR TITLE
Add guidance folder

### DIFF
--- a/guidance/README.md
+++ b/guidance/README.md
@@ -1,0 +1,14 @@
+# .NET Foundation Guidance
+
+In this section you can find the best practices and guidance shared with .NET Foundation projects.
+Feel free to [submit a Pull Request](https://github.com/dotnet/home/pulls) if you want to suggest changes or have a new area that you think
+would be useful to share as a recommended way of working with other projects.
+
+ - [New project checklist](new-projects.md)
+ - [Repo structure and common files](repo-guide.md)
+ - [What makes a good README](readme-guide.md)
+ - [Code of Conduct](be-nice.md)
+ - [File headers and copyright statements](copyright.md)
+
+
+

--- a/guidance/be-nice.md
+++ b/guidance/be-nice.md
@@ -1,0 +1,53 @@
+# Contributors Code of Conduct
+
+The .NET Foundation was created to foster an open, innovative and inclusive
+community around open source .NET. To clarify expected behaviour in our
+communities we have adopted the [Contributor Covenant](http://www.dotnetfoundation.org/code-of-conduct).
+This code of conduct has been adopted by [many other open source communities](http://contributor-covenant.org/adopters/)
+and we feel it expresses our values well. 
+
+For a full copy of the [code of conduct](http://www.dotnetfoundation.org/code-of-conduct),
+see the .NET Foundation Website http://www.dotnetfoundation.org/code-of-conduct
+
+## Applying the Code of Conduct to your project
+
+First of all, it is important that you read the [code of conduct](http://www.dotnetfoundation.org/code-of-conduct)
+and understand when to be on the look out for unnaceptable behaviour, what to do if you see
+it or if someone reports their concerns to you.
+
+Any concerns passed to you by your community should be forwarded to the
+.NET Foundation by email conduct@dotnetfoundation.org for help and advice.
+
+The .NET Foundation recommend that you also display a link to the code of conduct
+in your README.md file and in your CONTRIBUTING.md file if you have one.  You can
+see an example of this in the [Open Live Writer](http://github.com/openlivewriter/openlivewriter)
+project
+
+See the [README.md guidance](readme-guide.md) for the suggested MarkDown to use
+when linking to the Code of Conduct
+
+If introducing the Code of Conduct to an existing project, it is important 
+to do this via a Pull Request to allow the community time to read the code
+of conduct and make sure that they understand it.  Below are some FAQ's you 
+might find useful.
+
+## Code of Conduct F.A.Q's
+
+#### What happens when I report a concern?
+Instances of abusive, harassing, or otherwise unacceptable behavior may be 
+reported by contacting conduct@dotnetfoundation.org. 
+
+All complaints will be reviewed and investigated by two person, gender balanced
+team at the .NET Foundation and will result in a response that is deemed
+necessary and appropriate to the circumstances. The confidentiality of the
+person reporting the incident will be kept at all times by the .NET Foundation.
+
+#### Does anyone else do this?
+This code of conduct has been adopted by [many other open source communities](http://contributor-covenant.org/adopters/)
+including Mono, Rails, AngularJS, Eclipse, Swift and other projects in the .NET Foundation
+
+
+
+
+
+ 

--- a/guidance/be-nice.md
+++ b/guidance/be-nice.md
@@ -1,5 +1,9 @@
 # Contributors Code of Conduct
 
+This guidance is intended for project owners wanting to understand more about the 
+.NET Foundation Contributors Code of Conduct, why it exists and how to raise
+awareness of it in your community.
+
 The .NET Foundation was created to foster an open, innovative and inclusive
 community around open source .NET. To clarify expected behaviour in our
 communities we have adopted the [Contributor Covenant](http://www.dotnetfoundation.org/code-of-conduct).
@@ -15,8 +19,10 @@ First of all, it is important that you read the [code of conduct](http://www.dot
 and understand when to be on the look out for unnaceptable behaviour, what to do if you see
 it or if someone reports their concerns to you.
 
-Any concerns passed to you by your community should be forwarded to the
-.NET Foundation by email conduct@dotnetfoundation.org for help and advice.
+Any concerns passed to you by your community can be forwarded to the
+.NET Foundation by email to conduct@dotnetfoundation.org for help and advice. If a member of
+the community is not happy with the response of the project maintainers then
+they should email conduct@dotnetfoundation.org with details.
 
 The .NET Foundation recommend that you also display a link to the code of conduct
 in your README.md file and in your CONTRIBUTING.md file if you have one.  You can
@@ -26,7 +32,7 @@ project
 See the [README.md guidance](readme-guide.md) for the suggested MarkDown to use
 when linking to the Code of Conduct
 
-If introducing the Code of Conduct to an existing project, it is important 
+When introducing the Code of Conduct links to an existing project, it is important 
 to do this via a Pull Request to allow the community time to read the code
 of conduct and make sure that they understand it.  Below are some FAQ's you 
 might find useful.
@@ -37,17 +43,23 @@ might find useful.
 Instances of abusive, harassing, or otherwise unacceptable behavior may be 
 reported by contacting conduct@dotnetfoundation.org. 
 
-All complaints will be reviewed and investigated by two person, gender balanced
+All complaints will be reviewed and investigated by two person
 team at the .NET Foundation and will result in a response that is deemed
 necessary and appropriate to the circumstances. The confidentiality of the
 person reporting the incident will be kept at all times by the .NET Foundation.
+Where additional perspectives are needed, the team may seek additional insight
+from others with relevant expertise or experience but will maintain the
+confidentiality of the person reporting.
 
 #### Does anyone else do this?
 This code of conduct has been adopted by [many other open source communities](http://contributor-covenant.org/adopters/)
 including Mono, Rails, AngularJS, Eclipse, Swift and other projects in the .NET Foundation
 
-
-
-
+### What should I do when a thread goes toxic
+There are rare instances when a particular issue or thread in a forum will decend into a set of unhelpful comments,
+occasionally drawing in a large number of unhelpful comments from outside of your regular community.
+Rather than one individual being particularly problematic or harrasing another, a crowd might start to 
+turn on an individual or group. If any project maintainer wants advice on how to deal with a particular issue
+including when to lock an issue then please drop us a line on the conduct@dotnetfoundation.org address.
 
  

--- a/guidance/copyright.md
+++ b/guidance/copyright.md
@@ -5,7 +5,7 @@
 Generally the copyright notice for a project in the .NET Foundation is given as
 "Copyright (c) .NET Foundation and Contributors. All Rights Reserved".
 The copyright notice should be placed in the LICENSE for the project so
-the begginning of the LICENSE for an MIT Licensed project would be:
+the beginning of the LICENSE for an MIT Licensed project would be:
 
  ```
 The MIT License (MIT)
@@ -31,7 +31,9 @@ TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
  ```
 
 When including third party open source code in a project, any third party
-copyright notices should be preserved with the code.
+copyright notices should be preserved with the code.  It is good practise
+to also surface any third party notices required in your project
+into a file called NOTICE.md (or ThirdPartyNotices.txt) in the project root.
 
 ## File Headers
 
@@ -47,7 +49,7 @@ preserved.
 // See the LICENSE file in the project root for more information.
  ```
 
-Therfore the file header for an MIT licensed project would be:
+Therefore the file header for an MIT licensed project would be:
 
  ```
 // Licensed to the .NET Foundation under one or more agreements.

--- a/guidance/copyright.md
+++ b/guidance/copyright.md
@@ -1,0 +1,67 @@
+#File Headers and Copyright Statements
+
+## Copyright
+
+Generally the copyright notice for a project in the .NET Foundation is given as
+"Copyright (c) .NET Foundation and Contributors. All Rights Reserved".
+The copyright notice should be placed in the LICENSE for the project so
+the begginning of the LICENSE for an MIT Licensed project would be:
+
+ ```
+The MIT License (MIT)
+
+Copyright (c) .NET Foundation and Contributors
+All Rights Reserved
+
+Permission is hereby granted... 
+ ```
+ 
+And an Apache 2.0 Licensed project would begin
+
+ ```
+Copyright (c) .NET Foundation and Contributors
+All Rights Reserved
+
+Apache License, Version 2.0, January 2004
+http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions... 
+ ```
+
+When including third party open source code in a project, any third party
+copyright notices should be preserved with the code.
+
+## File Headers
+
+The following file header format is the used for .NET Foundation projects.
+Please use it for new files and update the headers of existing code files as
+appropriate. Note that the general copyright notice for the project is given
+in the project's LICENSE file but any third party copyright notices should be
+preserved.
+
+ ```
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the <<LICENSE_TYPE>> license.
+// See the LICENSE file in the project root for more information.
+ ```
+
+Therfore the file header for an MIT licensed project would be:
+
+ ```
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the MIT license.
+// See the LICENSE file in the project root for more information. 
+ ```
+
+Where-as the file header for an Apache 2.0 licensed project would be:
+
+ ```
+// Licensed to the .NET Foundation under one or more agreements.
+// The .NET Foundation licenses this file to you under the Apache 2.0 License.
+// See the LICENSE file in the project root for more information. 
+ ```
+
+The addition of existing files from other projects is handled on a case by case
+basis. If you require any help then please email contact@dotnetfoundation.org 

--- a/guidance/new-projects.md
+++ b/guidance/new-projects.md
@@ -1,0 +1,68 @@
+# New Project Checklist
+
+
+When projects join the foundation, there are two ways that they can come in.
+
+ - One is by the owners of the project signing a contribution agreement licensing
+   the code to the .NET Foundation under the terms of the open source license and
+   confirming that they have the rights to do that. This type of agreement is most
+   common when projects have had a long history of being open source but wish to
+   now be supported by the .NET Foundation.
+   
+ - The other is to assign the copyright of the project to the .NET Foundation and
+   confirm that they have the rights to do this. This type of agreement is usually
+   used when releasing something as open source for the first time or by a project
+   that has had a high degree of control over contributions in the past.  
+
+When you contact the .NET Foundation, they will help you decide which type of
+agreement is most likely to suit you.
+
+When on-boarding a project into the .NET Foundation, we typically go through
+the following steps to make sure everything is set up properly.  Feel free
+to copy the checklist below into a new issue in your project to make sure
+we remember to do everything or create individual issues for the items
+that are currently missing.
+
+ ```
+Title: On-Board project to the .NET Foundation
+
+We're getting ready to bring the project into the .NET Foundation, but before we
+do we need to do the following:
+
+## Getting into the .NET Foundation
+- [ ] Make sure the project has a good name that is easy to remember and 
+  spell. Check that it doesn't [conflict with another existing project](http://ivantomic.com/projects/ospnc/)
+- [ ] Make sure the people involved in the project want to join the .NET Foundation
+- [ ] Make sure the project has a clear understanding about how it accepts contributions and the process
+      it follows when selecting new committers to the project.
+- [ ] [Register an interest](http://www.dotnetfoundation.org/get-involved) in joining the .NET Foundation
+- [ ] Work with the .NET Foundation to fill out an On-Boarding Questionaire
+- [ ] .NET Foundation send out completed questionaire to .NET Foundation Advisory Council for comments
+- [ ] .NET Foundation Executive Director submit new project proposal to the .NET Foundation Board
+- [ ] Configure a CI build for the project and ensure build status badges are available from the README
+
+## Once accepted into the .NET Foundation
+ - [ ] Sign the contribution / assignment agreement
+ - [ ] Agree a date to move into the .NET Foundation
+ - [ ] Prepare a guest blog post announcing the move on the .NET Foundation Blog
+ - [ ] Read the [code of conduct](http://www.dotnetfoundation.org/code-of-conduct), 
+       [link to it in your code](be-nice.md) and 
+       understand what to do if you are concerned about any behaviour or have
+       concerns reported to you.
+ - [ ] Tell the world we have joined!
+ - [ ] Get CLA Automation enabled to ensure contributors can easily sign the 
+       [Contribution License Agreement](https://cla2.dotnetfoundation.org/cladoc/net-foundation-contribution-license-agreement.pdf)
+ - [ ] Send a PR to [add the Project into the .NET Foundation list](https://github.com/dotnet/home/tree/master/projects)
+ - [ ] Ensure the repo contents are up to date with [.NET Foundation guidance](repo-guide.md)
+ - [ ] Review the [README guidance](readme-guide.md) and update if necessary
+ - [ ] If applicable [update the LICENSE file](copyright.md) to show Copyright has been assigned to the .NET Foundation
+       and look to update any file headers.
+ - [ ] If applicable, update any copyright statements in websites owned by the project to refelct assignment to the .NET Foundation
+ - [ ] If applicable, update any websites associated with the project to include "Supported by the <a href="http://dotnetfoundation.org">.NET Foundation</a>" or
+       similar link back to the .NET Foundation in the footer.
+ - [ ] [Sign up for Project Leader news](http://eepurl.com/bOCfJP)
+ - [ ] Configure any resources requested from the .NET Foundation (SSL Certs, Code Signing, Secret Management, Build Servers etc)
+ ```
+
+
+

--- a/guidance/new-projects.md
+++ b/guidance/new-projects.md
@@ -3,19 +3,22 @@
 
 When projects join the foundation, there are two ways that they can come in.
 
- - One is by the owners of the project signing a contribution agreement licensing
+ - **License** - The first is for the maintainers of the project to sign a
+   contribution agreement licensing
    the code to the .NET Foundation under the terms of the open source license and
    confirming that they have the rights to do that. This type of agreement is most
-   common when projects have had a long history of being open source but wish to
+   common when projects have had a long history of being open source, with lots of
+   contribution from many different individuals and the project community now wish to
    now be supported by the .NET Foundation.
    
- - The other is to assign the copyright of the project to the .NET Foundation and
+ - **Assignment** - The other is to assign the copyright of the project to the .NET Foundation and
    confirm that they have the rights to do this. This type of agreement is usually
    used when releasing something as open source for the first time or by a project
-   that has had a high degree of control over contributions in the past.  
+   that has had a high degree of control over contributions to the existing project 
+   in the past.  
 
 When you contact the .NET Foundation, they will help you decide which type of
-agreement is most likely to suit you.
+agreement is most likely to suit you based on your needs.
 
 When on-boarding a project into the .NET Foundation, we typically go through
 the following steps to make sure everything is set up properly.  Feel free

--- a/guidance/readme-guide.md
+++ b/guidance/readme-guide.md
@@ -1,0 +1,58 @@
+# Crafting a good README
+README files are very important in welcoming people to your open source
+project for the first time. When someone discovers your code, the README.md
+file in the root of the repository is the first thing that they will see
+there it is worth spending some time on it to make sure it has relevant
+information to your audience and is kept up to date.
+
+Remember that often your project is targeted at fellow developers and
+developers love code. If your project is a library then show some quick
+[syntax highlighted](https://help.github.com/articles/creating-and-highlighting-code-blocks/)
+examples of how to call your project. Ideally link to some examples in your 
+/Documentation folder for more information. A couple of informative Images can
+also very useful.
+
+If you have lots of information for a particular topic then it is good to split that
+out into a seperate file in your /Documentation folder with a link in the README. 
+But you should make sure you have the following areas referenced in your README. 
+
+ - A one paragraph summary of your project
+ - The status of the project (i.e. shipping / used in production / 
+   experimental / sample / documentation / orphaned or superseeded etc)
+ - The current CI Build Status with a red/green badge linking to publicly
+   accessible build results.
+ - Details description of the project, what problem it solves and why they
+   should use it.
+ - How do you install and use your code?
+ - Any related projects that the user should know about. If your project is 
+   similar to another open source project that is popular then how does your
+   project solve the problem differently.
+ - How to contribute to the project or a link to the CONTRIBUTE.md
+ - Information on how to get started as a developer, information on Gitter, IRC, mailing list etc
+ - How to provide feedbad (Issues, User Voice, Forums etc)
+ - License type and link to the project LICENCE
+ - High level road map or link to roadmap documentation / open issues
+
+### Code of Conduct
+The .NET Foundation has adopted the [Contributor Covenant](http://www.dotnetfoundation.org/code-of-conduct)
+You can read [more guidance on the Code of Conduct here](be-nice.md). However, it is
+good practice to include the following text somewhere appropriate in your README.
+
+ ```
+This project has adopted the code of conduct defined by the [Contributor Covenant](http://contributor-covenant.org/)
+to clarify expected behavior in our community.
+For more information see the [.NET Foundation Code of Conduct](http://www.dotnetfoundation.org/code-of-conduct). 
+ ```
+
+### .NET Foundation Pointer
+As .NET Foundation projects can be located across a number of different locations
+and organization on GitHub, if possible can your project also include a link back
+to the .NET Foundation website to help people discover other projects in the foundation
+as well as learn more about our joint goals.  The following simple MarkDown at the 
+end of your README is more than enough.
+ ```
+### .NET Foundation
+
+This project is supported by the [.NET Foundation](http://www.dotnetfoundation.org).
+ 
+ ```

--- a/guidance/repo-guide.md
+++ b/guidance/repo-guide.md
@@ -1,0 +1,40 @@
+# Repository Layout Guidance
+
+This guidance is aimed at helping ensure people can navigate your project
+source code easily and have a good experience when browsing and contributing
+to your project.
+
+Your repository should contain the following files in the root folder
+
+ - LICENSE (or LICENSE.txt / LICENSE.md) - Always provide a full copy of the open source
+   license associated with the project. At the top of the license file you should have
+   the project copyright statement, i.e.
+  '''
+    Copyright (c) .NET Foundation and Contributors
+    All Rights Reserved
+  '''   
+   
+ - [README.md](readme-guide.md)
+ - .gitignore - To configure which files should not be checked in to version
+                control (see the [Visual Studio template](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore))
+ - .gitattributes - Specify file ending conversion used and other common configuration parameters for your repo
+ - CONTRIBUTING.md - Details on how to contribute to the project, what coding standards to use
+                     what the criteria are to decide if a pull request will be accepted, 
+                     how to build and test, how to sign the CLA,
+                     how to log a good issue / bug etc. Note that this information
+                     may be in the README.md but if it is in a seperate file called
+                     CONTRIBUTING.md then a link will be displayed when someone
+                     created a new issue or PR against your project.
+ - NOTICE.md - _optional_ If the project contains and third party open source code
+              then full details of that along with a full copy of the associated
+              open source license should be provided.
+ - Documentation/ - Is is a good practice to include project documentation in 
+                    MarkDown format. If included with the source code then place
+                    in a folder called "Documentation" with a capital D so that it
+                    appears towards the top of the directory structure when browsing
+                    in GitHub. Note that storing documentation in a repo means
+                    that anyone can contribute to that documentation and you can
+                    use Pull Requests to review / discuss changes.
+ 
+You should set up alerts so that you get notified when someone creates a new issue
+or submits a pull request so that you can respond quickly with feedback.

--- a/guidance/repo-guide.md
+++ b/guidance/repo-guide.md
@@ -9,26 +9,25 @@ Your repository should contain the following files in the root folder
  - LICENSE (or LICENSE.txt / LICENSE.md) - Always provide a full copy of the open source
    license associated with the project. At the top of the license file you should have
    the project copyright statement, i.e.
-  '''
-    Copyright (c) .NET Foundation and Contributors
-    All Rights Reserved
-  '''   
-   
- - [README.md](readme-guide.md)
- - .gitignore - To configure which files should not be checked in to version
+         ```
+           Copyright (c) .NET Foundation and Contributors
+           All Rights Reserved
+         ```   
+ - [*README.md*](readme-guide.md)
+ - *.gitignore* - To configure which files should not be checked in to version
                 control (see the [Visual Studio template](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore))
- - .gitattributes - Specify file ending conversion used and other common configuration parameters for your repo
- - CONTRIBUTING.md - Details on how to contribute to the project, what coding standards to use
+ - *.gitattributes* - Specify file ending conversion used and other common configuration parameters for your repo
+ - *CONTRIBUTING.md* - Details on how to contribute to the project, what coding standards to use
                      what the criteria are to decide if a pull request will be accepted, 
                      how to build and test, how to sign the CLA,
                      how to log a good issue / bug etc. Note that this information
                      may be in the README.md but if it is in a seperate file called
                      CONTRIBUTING.md then a link will be displayed when someone
                      created a new issue or PR against your project.
- - NOTICE.md - _optional_ If the project contains and third party open source code
+ - *NOTICE.md* - _optional_ If the project contains and third party open source code
               then full details of that along with a full copy of the associated
               open source license should be provided.
- - Documentation/ - Is is a good practice to include project documentation in 
+ - *Documentation/* - Is is a good practice to include project documentation in 
                     MarkDown format. If included with the source code then place
                     in a folder called "Documentation" with a capital D so that it
                     appears towards the top of the directory structure when browsing

--- a/guidance/repo-guide.md
+++ b/guidance/repo-guide.md
@@ -9,31 +9,38 @@ Your repository should contain the following files in the root folder
  - LICENSE (or LICENSE.txt / LICENSE.md) - Always provide a full copy of the open source
    license associated with the project. At the top of the license file you should have
    the project copyright statement, i.e.
-         ```
+   ```
            Copyright (c) .NET Foundation and Contributors
            All Rights Reserved
-         ```   
+   ```
  - [*README.md*](readme-guide.md)
+ 
  - *.gitignore* - To configure which files should not be checked in to version
-                control (see the [Visual Studio template](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore))
+   control (see the [Visual Studio template](https://github.com/github/gitignore/blob/master/VisualStudio.gitignore))
+   
  - *.gitattributes* - Specify file ending conversion used and other common configuration parameters for your repo
+
  - *CONTRIBUTING.md* - Details on how to contribute to the project, what coding standards to use
-                     what the criteria are to decide if a pull request will be accepted, 
-                     how to build and test, how to sign the CLA,
-                     how to log a good issue / bug etc. Note that this information
-                     may be in the README.md but if it is in a seperate file called
-                     CONTRIBUTING.md then a link will be displayed when someone
-                     created a new issue or PR against your project.
+   what the criteria are to decide if a pull request will be accepted, 
+   how to build and test, how to sign the CLA,
+   how to log a good issue / bug etc. Note that this information
+   may be in the README.md but if it is in a seperate file called
+   CONTRIBUTING.md then a link will be displayed when someone
+   created a new issue or PR against your project.
+   
  - *NOTICE.md* - _optional_ If the project contains and third party open source code
-              then full details of that along with a full copy of the associated
-              open source license should be provided.
+   then full details of that along with a full copy of the associated
+   open source license should be provided.
+   
  - *Documentation/* - Is is a good practice to include project documentation in 
-                    MarkDown format. If included with the source code then place
-                    in a folder called "Documentation" with a capital D so that it
-                    appears towards the top of the directory structure when browsing
-                    in GitHub. Note that storing documentation in a repo means
-                    that anyone can contribute to that documentation and you can
-                    use Pull Requests to review / discuss changes.
+    MarkDown format and have a link to it in the README. If included
+    with the source code then place in a folder called "Documentation"
+    with a capital D so that it appears towards the top of the
+    directory structure when browsing in GitHub.
+    Note that storing documentation in a repo means
+    that anyone can contribute to that documentation and you can
+    use Pull Requests to review / discuss changes. For many projects
+    a documentation repo or folder works better than a GitHub Wiki.
  
 You should set up alerts so that you get notified when someone creates a new issue
 or submits a pull request so that you can respond quickly with feedback.


### PR DESCRIPTION
I wanted to pull together the begginings of our guidance documentation and thought that the home repo was the best place for this to live.  Let me know what you think.  Once we have some basics in we can iterate and add more as we go along.